### PR TITLE
Make two inner classes in S3ConfigFetcher public (necessary to make the

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,8 @@
 # Release Notes
 
-## 1.0.16 / 2018-05-08 Make some ,migrated methods public
+## 1.0.17 / 2018-05-08 Make S3ConfigFetcher.Factory class public
+
+## 1.0.16 / 2018-05-08 Make some migrated methods public
 These methods were package private in haystack-pipes but need to be public after being moved.
 
 ## 1.0.15 / 2018-05-08 More Java classes from secret-detector

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-commons</artifactId>
-    <version>1.0.16-SNAPSHOT</version>
+    <version>1.0.17-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/S3ConfigFetcher.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/S3ConfigFetcher.java
@@ -171,13 +171,13 @@ public class S3ConfigFetcher {
         throw new InvalidWhitelistItemInputException(line);
     }
 
-    static class InvalidWhitelistItemInputException extends Exception {
+    public static class InvalidWhitelistItemInputException extends Exception {
         InvalidWhitelistItemInputException(String line) {
             super(String.format(INVALID_DATA_MSG, line));
         }
     }
 
-    static class Factory {
+    public static class Factory {
         long createCurrentTimeMillis() {
             return System.currentTimeMillis();
         }


### PR DESCRIPTION
classes usable in pipes and elsewhere).