### PR TITLE
Make SpanS3ConfigFetcher.SpanFactory and XmlS3ConfigFetcher.XmlFactor…

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,9 @@
 # Release Notes
 
-## 1.0.21 / 2018-05-17 Added an XML secret detectorª
+## 1.0.22 / 2018-05-17 Make SpanS3ConfigFetcher.SpanFactory and XmlS3ConfigFetcher.XmlFactory public
+These classes need to be public so that the can be wired by Spring in the haystack-pipes package.
+
+## 1.0.21 / 2018-05-17 Added an XML secret detector
 
 ## 1.0.20 / 2018-05-14 Add some convenience constructors to to some of the classes moved from Pipes
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-commons</artifactId>
-    <version>1.0.21-SNAPSHOT</version>
+    <version>1.0.22-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/span/SpanS3ConfigFetcher.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/span/SpanS3ConfigFetcher.java
@@ -78,7 +78,7 @@ public class SpanS3ConfigFetcher extends S3ConfigFetcherBase {
         tags.add(spanWhiteListItem.getTagName());
     }
 
-    static class SpanFactory extends S3ConfigFetcherBase.Factory<SpanWhiteListItem> {
+    public static class SpanFactory extends S3ConfigFetcherBase.Factory<SpanWhiteListItem> {
         @Override
         public SpanWhiteListItem createWhiteListItem(String... items) {
             return new SpanWhiteListItem(items[0], items[1], items[2], items[3]);

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlS3ConfigFetcher.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlS3ConfigFetcher.java
@@ -66,7 +66,7 @@ public class XmlS3ConfigFetcher extends S3ConfigFetcherBase {
         xmlPaths.add(xmlWhiteListItem.getXmlPath());
     }
 
-    static class SpanFactory extends Factory<XmlWhiteListItem> {
+    public static class SpanFactory extends Factory<XmlWhiteListItem> {
         @Override
         public XmlWhiteListItem createWhiteListItem(String... items) {
             return new XmlWhiteListItem(items[0], items[1]);


### PR DESCRIPTION
…y public

These classes need to be public so that the can be wired by Spring in the haystack-pipes package.