### PR TITLE
Make XmlDetector not implement ValueMapper

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.0.23 / 2018-05-17 Make XmlDetector not implement ValueMapper
+This class is only used by haystack-data-scrubber, which doesn't have a dependency on any Kafka code.
+(ValueMapper is a Kafka class.) The XmlDetector.apply() method and its tests are now commented out. 
+
 ## 1.0.22 / 2018-05-17 Make SpanS3ConfigFetcher.SpanFactory and XmlS3ConfigFetcher.XmlFactory public
 These classes need to be public so that the can be wired by Spring in the haystack-pipes package.
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-commons</artifactId>
-    <version>1.0.22-SNAPSHOT</version>
+    <version>1.0.23-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetector.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetector.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * Finds the names of elements or attributes whose values are secrets.
  */
 @SuppressWarnings("WeakerAccess")
-public class XmlDetector extends DetectorBase implements ValueMapper<Document, Iterable<String>> {
+public class XmlDetector extends DetectorBase {
     @VisibleForTesting
     static final String TEXT_TEMPLATE = "Confidential data has been found in an XML BLOB: %s";
     private static final String[] ZERO_LENGTH_STRING_ARRAY = new String[0];
@@ -117,7 +117,7 @@ public class XmlDetector extends DetectorBase implements ValueMapper<Document, I
         } while (node != null);
         return String.join("/", nodeList.toArray(ZERO_LENGTH_STRING_ARRAY));
     }
-
+/*
     @SuppressWarnings("MethodWithMultipleLoops")
     @Override
     public Iterable<String> apply(@SuppressWarnings("ParameterNameDiffersFromOverriddenParameter") Document document) {
@@ -138,7 +138,7 @@ public class XmlDetector extends DetectorBase implements ValueMapper<Document, I
         }
         return mapOfTypeToKeysOfSecrets.isEmpty() ? Collections.emptyList() : Collections.singleton(emailText);
     }
-
+*/
     @SuppressWarnings("WeakerAccess")
     public static String getEmailText(Map<String, List<String>> mapOfTypeToKeysOfSecrets) {
         return String.format(TEXT_TEMPLATE, mapOfTypeToKeysOfSecrets.toString());

--- a/src/test/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetectorTest.java
+++ b/src/test/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetectorTest.java
@@ -35,15 +35,10 @@ import java.util.Map;
 
 import static com.expedia.www.haystack.commons.secretDetector.TestConstantsAndCommonCode.EMAIL_ADDRESS;
 import static com.expedia.www.haystack.commons.secretDetector.TestConstantsAndCommonCode.RANDOM;
-import static com.expedia.www.haystack.commons.secretDetector.xml.XmlDetector.TEXT_TEMPLATE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("MultipleExceptionsDeclaredOnTestMethod")
 @RunWith(MockitoJUnitRunner.class)
@@ -123,7 +118,7 @@ public class XmlDetectorTest {
     public void testFindSecretsEmailAddressInChildElementText() {
         testFindSecretsContainsSecret(DOCUMENT_EMAIL_IN_CHILD_TEXT, DOCUMENT_EMAIL_IN_CHILD_TEXT_ID);
     }
-
+/*
     @Test
     public void testApplyNoSecret() {
         final Iterable<String> iterable = xmlDetector.apply(DOCUMENT_NO_SECRETS);
@@ -183,7 +178,7 @@ public class XmlDetectorTest {
         }
         verify(mockXmlS3ConfigFetcher).isInWhiteList("Email", id);
     }
-
+*/
     private void testFindSecretsContainsSecret(Document document, String expected) {
         final Map<String, List<String>> secrets = xmlDetector.findSecrets(document);
         assertEquals(1, secrets.size());


### PR DESCRIPTION
This class is only used by haystack-data-scrubber, which doesn't have a dependency on any Kafka code.
(ValueMapper is a Kafka class.) The XmlDetector.apply() method and its tests are now commented out.