### PR TITLE
Don't spam logs when white list cannot be fetched from S3

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.0.27 / 2018-05-24 Don't spam logs when white list cannot be fetched from S3 (only write error once per hour)
+
+## 1.0.26 / 2018-05-24 Make more dependencies provided
+
 ## 1.0.25 / 2018-05-23 Make SpanSecretMasker.Factory.createCounter() return a counter in the "errors" metric group
 Our use of PCI/PII finders has evolved from "detection" to "masking" and the counters that are counting what secret
 data has been found need to show on the same Grafana graph, so that metric names must match, which they did not before

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-commons</artifactId>
-    <version>1.0.26-SNAPSHOT</version>
+    <version>1.0.27-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/S3ConfigFetcherBase.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/S3ConfigFetcherBase.java
@@ -111,7 +111,6 @@ public abstract class S3ConfigFetcherBase {
             if (isUpdateInProgress.compareAndSet(false, true)) {
                 try {
                     whiteList.set(readAllWhiteListItemsFromS3());
-                    lastUpdateTime.set(now);
                     logger.info(SUCCESSFUL_WHITELIST_UPDATE_MSG);
                 } catch (InvalidWhitelistItemInputException e) {
                     logger.error(e.getMessage(), e);
@@ -119,6 +118,8 @@ public abstract class S3ConfigFetcherBase {
                     logger.error(ERROR_MESSAGE, e);
                 } finally {
                     isUpdateInProgress.set(false);
+                    // Set last update time for successes and failures, to avoid log spamming for a persistent error
+                    lastUpdateTime.set(now);
                 }
             }
         }

--- a/src/test/java/com/expedia/www/haystack/commons/secretDetector/span/SpanS3ConfigFetcherTest.java
+++ b/src/test/java/com/expedia/www/haystack/commons/secretDetector/span/SpanS3ConfigFetcherTest.java
@@ -175,7 +175,7 @@ public class SpanS3ConfigFetcherTest {
 
         final Map<String, Map<String, Map<String, Set<String>>>> whiteList =
                 (Map<String, Map<String, Map<String, Set<String>>>>) spanS3ConfigFetcher.getWhiteListItems();
-        assertsForEmptyWhiteList(whiteList, true);
+        assertsForEmptyWhiteList(whiteList, true, 0L);
 
         verify(mockFactory).createCurrentTimeMillis();
     }
@@ -189,7 +189,7 @@ public class SpanS3ConfigFetcherTest {
 
         final Map<String, Map<String, Map<String, Set<String>>>> whiteList =
                 (Map<String, Map<String, Map<String, Set<String>>>>) spanS3ConfigFetcher.getWhiteListItems();
-        assertsForEmptyWhiteList(whiteList, false);
+        assertsForEmptyWhiteList(whiteList, false, MORE_THAN_ONE_HOUR);
 
         verifiesForGetWhiteListItems(1, 1);
         verify(mockS3ConfigFetcherLogger).error(ERROR_MESSAGE, ioException);
@@ -203,7 +203,7 @@ public class SpanS3ConfigFetcherTest {
 
         final Map<String, Map<String, Map<String, Set<String>>>> whiteList =
                 (Map<String, Map<String, Map<String, Set<String>>>>) spanS3ConfigFetcher.getWhiteListItems();
-        assertsForEmptyWhiteList(whiteList, false);
+        assertsForEmptyWhiteList(whiteList, false, MORE_THAN_ONE_HOUR);
 
         verifiesForGetWhiteListItems(1, 1);
         verify(mockS3ConfigFetcherLogger).error(eq(String.format(INVALID_DATA_MSG, ONE_LINE_OF_BAD_DATA, 3)),
@@ -211,9 +211,10 @@ public class SpanS3ConfigFetcherTest {
     }
 
     private void assertsForEmptyWhiteList(Map<String, Map<String, Map<String, Set<String>>>> whiteList,
-                                          boolean isUpdateInProgress) {
+                                          boolean isUpdateInProgress,
+                                          long lastUpdateTime) {
         assertNull(whiteList);
-        assertEquals(0L, spanS3ConfigFetcher.getLastUpdateTimeForTest());
+        assertEquals(lastUpdateTime, spanS3ConfigFetcher.getLastUpdateTimeForTest());
         assertEquals(isUpdateInProgress, spanS3ConfigFetcher.isUpdateInProgressForTest());
     }
 

--- a/src/test/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlS3ConfigFetcherTest.java
+++ b/src/test/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlS3ConfigFetcherTest.java
@@ -170,7 +170,7 @@ public class XmlS3ConfigFetcherTest {
 
         final Map<String, Set<String>> whiteList =
                 (Map<String, Set<String>>) spanS3ConfigFetcher.getWhiteListItems();
-        assertsForEmptyWhiteList(whiteList, true);
+        assertsForEmptyWhiteList(whiteList, true, 0);
 
         verify(mockFactory).createCurrentTimeMillis();
     }
@@ -184,7 +184,7 @@ public class XmlS3ConfigFetcherTest {
 
         final Map<String, Set<String>> whiteList =
                 (Map<String, Set<String>>) spanS3ConfigFetcher.getWhiteListItems();
-        assertsForEmptyWhiteList(whiteList, false);
+        assertsForEmptyWhiteList(whiteList, false, MORE_THAN_ONE_HOUR);
 
         verifiesForGetWhiteListItems(1, 1);
         verify(mockS3ConfigFetcherLogger).error(ERROR_MESSAGE, ioException);
@@ -198,7 +198,7 @@ public class XmlS3ConfigFetcherTest {
 
         final Map<String, Set<String>> whiteList =
                 (Map<String, Set<String>>) spanS3ConfigFetcher.getWhiteListItems();
-        assertsForEmptyWhiteList(whiteList, false);
+        assertsForEmptyWhiteList(whiteList, false, MORE_THAN_ONE_HOUR);
 
         verifiesForGetWhiteListItems(1, 1);
         verify(mockS3ConfigFetcherLogger).error(eq(String.format(INVALID_DATA_MSG, ONE_LINE_OF_BAD_DATA, 1)),
@@ -206,9 +206,10 @@ public class XmlS3ConfigFetcherTest {
     }
 
     private void assertsForEmptyWhiteList(Map<String, Set<String>> whiteList,
-                                          boolean isUpdateInProgress) {
+                                          boolean isUpdateInProgress,
+                                          long lastUpdateTime) {
         assertNull(whiteList);
-        assertEquals(0L, spanS3ConfigFetcher.getLastUpdateTimeForTest());
+        assertEquals(lastUpdateTime, spanS3ConfigFetcher.getLastUpdateTimeForTest());
         assertEquals(isUpdateInProgress, spanS3ConfigFetcher.isUpdateInProgressForTest());
     }
 


### PR DESCRIPTION
(only write error once per hour)